### PR TITLE
Don't create empty file on failure to fetch artifact

### DIFF
--- a/script/build_utils.py
+++ b/script/build_utils.py
@@ -79,10 +79,11 @@ def has_newer(sources, targets):
 def fetch(url, file):
   if not os.path.exists(file):
     print('Downloading', url)
+    data = urllib.request.urlopen(url).read()
     if os.path.dirname(file):
       makedirs(os.path.dirname(file))
     with open(file, 'wb') as f:
-      f.write(urllib.request.urlopen(url).read())
+      f.write(data)
 
 def fetch_maven(group, name, version, classifier=None, repo='https://repo1.maven.org/maven2'):
   path = '/'.join([group.replace('.', '/'), name, version, name + '-' + version + ('-' + classifier if classifier else '') + '.jar'])


### PR DESCRIPTION
When `urllib.request.urlopen(url).read()` throws an exception, an empty file gets created, making following calls to `run.py` "succeed" (and fail later with `java.lang.ClassNotFoundException`). This PR fixes that.

~By the way, you forgot to publish JWM 0.4.0.~