### PR TITLE
Custom UI Element

### DIFF
--- a/src/io/github/humbleui/ui.clj
+++ b/src/io/github/humbleui/ui.clj
@@ -664,6 +664,31 @@
     (doto (Paint.) (.setColor (unchecked-int 0x60000000)))
     nil))
 
+(deftype+ CustomUI [width height on-paint on-event ^:mut child-rect]
+  IComponent
+  (-measure [_ ctx cs]
+    (IPoint. width height))
+  (-draw [_ ctx cs ^Canvas canvas]
+    (set! child-rect (IRect/makeXYWH 0 0 (:width cs) (:height cs)))
+    (when on-paint
+      (let [canvas ^Canvas canvas
+            {:keys [width height]} cs
+            layer  (.save canvas)
+            rect  (Rect/makeXYWH 0 0 width height)]
+        (try
+          (on-paint canvas width height)
+          (finally
+            (.restoreToCount canvas layer))))))
+  (-event [_ event]
+    (when on-event
+      (on-event event))))
+
+(defn custom-ui
+  "(custom-ui 400 300 {:on-paint #'on-paint-impl
+                       :on-event #'on-event-impl})"
+  [width height {:keys [on-paint on-event]}]
+  (->CustomUI width height on-paint on-event nil))
+
 (deftype+ KeyListener [event-type callback child ^:mut child-rect]
   IComponent
   (-measure [_ ctx cs]


### PR DESCRIPTION
Finally figured out what the problem was with my custom component performance.

I've been using this to add in rounded radio buttons for the jam =)...

```clojure
(defn draw-radio-toggle-impl [fill scale]
  (fn [^Canvas canvas _window-width _window-height]
    (let [border (doto (Paint.)
                   (.setColor (unchecked-int 0xFF000000))
                   (.setMode PaintMode/STROKE)
                   (.setStrokeWidth (* 1 scale)))]
      (.drawCircle canvas 5 5 10 border)
      (.drawCircle canvas 5 5 6 fill))))

(defn radio-button [value selected-path child]
  (ui/clickable
    #(swap! *state assoc-in selected-path value)
    (ui/dynamic ctx [{:keys [fill-green fill-black scale]} ctx
                     selected (get-in @*state selected-path)]
      (ui/column
        (ui/row
          (ui/custom-ui 20 20
            {:on-paint (#'draw-radio-toggle-impl (if (= selected value) fill-black fill-green) scale)}))
        (ui/gap 5 0)
        child))))
```
![radio button image](https://user-images.githubusercontent.com/123055/157342344-c1ab7dd3-434d-4b1f-85c2-08a37a092a28.png)

I've removed all of the try catch stuff I originally had to make it in line with your own components.

Let me know if there's anything you'd like me to change, but I do think this would be useful to just draw stuff.