### PR TITLE
Adding tooltip functionality

### DIFF
--- a/src/io/github/humbleui/ui.clj
+++ b/src/io/github/humbleui/ui.clj
@@ -917,13 +917,15 @@
 (defn tooltip
   ([tip child] (tooltip {} tip child))
   ([opts tip child]
-   (hoverable
-     (dynamic ctx [{:keys [hui/active? hui/hovered?]} ctx]
-       (let [tip' (cond
-                    active?  tip
-                    hovered? tip
-                    :else    (gap 0 0))]
-         (relative-rect opts tip' child))))))
+   (valign 0
+     (halign 0
+       (hoverable
+         (dynamic ctx [{:keys [hui/active? hui/hovered?]} ctx]
+           (let [tip' (cond
+                        active?  tip
+                        hovered? tip
+                        :else    (gap 0 0))]
+             (relative-rect opts tip' child))))))))
 
 
 ; (require 'user :reload)


### PR DESCRIPTION
@tonsky, I got around to writing tooltips:
```clojure
(ui/dynamic ctx [{:keys [fill-dark-gray fill-yellow]} ctx]
  (ui/valign 0.5
    (ui/row
      [:stretch 1 nil]
      [:stretch 2
       (ui/column
         (custom-ui/tooltip {:anchor :top-left :shackle :top-right
                             :left -10 :up 0}
           (ui/fill fill-dark-gray
             (ui/row
               (ui/width 120
                 (ui/height 25
                   (ui/label "TOOLTIP")))))
           (ui/column
             (ui/row
               (ui/width 200
                 (ui/height 300
                   (ui/fill (paint/fill 0xFFEFFAFF)
                     (ui/fill fill-yellow
                       (ui/label "TOOLTIP TEST")))))))))]
      [:stretch 1 nil])))
```

Code above produces on hover:
![image](https://user-images.githubusercontent.com/123055/168702924-6587cd49-df1f-4107-b934-90e35889d7be.png)

Let me know if the api isn't to your liking.