### PR TITLE
Fix canvas example

### DIFF
--- a/dev/examples/canvas.clj
+++ b/dev/examples/canvas.clj
@@ -30,7 +30,7 @@
 
 (def *last-event (atom nil))
 
-(defn on-event [e]
+(defn on-event [_ e]
   (when-not (#{:frame :frame-skija} (:event e))
     (reset! *last-event e)
     true))


### PR DESCRIPTION
Now the "Canvas" example logs events instead of throwing errors.