### PR TITLE
Toggle: lerp between active colors if active

### DIFF
--- a/src/io/github/humbleui/ui/toggle.clj
+++ b/src/io/github/humbleui/ui/toggle.clj
@@ -58,15 +58,15 @@
                              fill-enabled-active
                              fill-disabled-active
                              fill-handle-active]} ctx
-          fill         (core/match [enabled? animating? active?]
-                         [true  true  _]     (paint/fill
-                                               (Color/makeLerp (.getColor fill-enabled) (.getColor fill-disabled) ratio))
-                         [false true  _]     (paint/fill
-                                               (Color/makeLerp (.getColor fill-disabled) (.getColor fill-enabled) ratio))
-                         [true  false false] fill-enabled
-                         [false false false] fill-disabled
-                         [true  false true]  fill-enabled-active
-                         [false false true]  fill-disabled-active)
+          fill         (let [fill-enabled (if active? fill-enabled-active fill-enabled)
+                             fill-disabled (if active? fill-disabled-active fill-disabled)]
+                         (core/match [enabled? animating? active?]
+                           [true  true  _]     (paint/fill
+                                                 (Color/makeLerp (.getColor fill-enabled) (.getColor fill-disabled) ratio))
+                           [false true  _]     (paint/fill
+                                                 (Color/makeLerp (.getColor fill-disabled) (.getColor fill-enabled) ratio))
+                           [true  false _] fill-enabled
+                           [false false _] fill-disabled))
           padding      (/ h 16)
           handle-r     (-> h (- (* 2 padding)) (/ 2))
           handle-left  (-> x (+ padding) (+ handle-r))


### PR DESCRIPTION
Not really observable unless animation length is slowed down.

![lerp-active](https://user-images.githubusercontent.com/287396/188544871-20a1cb23-befe-4eb6-ba0d-e798e2c5e25d.gif)
