### PR TITLE
Add border for examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 hs_err_pid*.log
 .cpcache
 target
+*.diff

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -80,6 +80,12 @@
       (next)
       (first))))
 
+(def light-grey 0xffeeeeee)   
+
+(def border-line
+  (ui/rect (paint/fill light-grey)
+    (ui/gap 1 0)))
+      
 (def app
   (ui/default-theme {; :font-size 13
                      ; :cap-height 10
@@ -105,6 +111,7 @@
                         selected? (ui/rect (paint/fill 0xFFB2D7FE) label)
                         hovered?  (ui/rect (paint/fill 0xFFE1EFFA) label)
                         :else     label)))))))))
+      border-line
       [:stretch 1
        (ui/clip
          (ui/dynamic _ [ui @(requiring-resolve (symbol (str "examples." @*example) "ui"))]


### PR DESCRIPTION
Adds a small 1px border line between the examples list and their implementation.

![Screenshot from 2022-09-28 15-47-09](https://user-images.githubusercontent.com/98485/192885615-30d13aa7-f658-49eb-bd6a-bfe4bd5da76e.png)
