### PR TITLE
making event/mask->set a bit faster

### DIFF
--- a/src/io/github/humbleui/event.clj
+++ b/src/io/github/humbleui/event.clj
@@ -25,21 +25,13 @@
     [io.github.humbleui.jwm.skija
      EventFrameSkija]))
 
+(defn- log2 [x]
+ (/ (Math/log x) (Math/log 2)))
+
 (defn- mask->set [mask keys]
-  (if (= 0 mask)
-    #{}
-    (persistent!
-      (loop [acc  (transient #{})
-             bit  0
-             keys keys]
-        (if (empty? keys)
-          acc
-          (recur
-            (if (bit-test mask bit)
-              (conj! acc (first keys))
-              acc)
-            (inc bit)
-            (next keys)))))))
+ (let [n (-> mask Long/highestOneBit log2 inc)
+       pred #(if (bit-test mask %1) %2 nil)]
+   (->> keys (take n) (keep-indexed pred) (into #{}))))
 
 (defn- modifiers->set [modifiers]
   (mask->set modifiers [:caps-lock :shift :control :alt :win-logo :linux-meta :linux-super :mac-command :mac-option :mac-fn]))

--- a/src/io/github/humbleui/event.clj
+++ b/src/io/github/humbleui/event.clj
@@ -25,13 +25,20 @@
     [io.github.humbleui.jwm.skija
      EventFrameSkija]))
 
-(defn- log2 [x]
- (/ (Math/log x) (Math/log 2)))
-
 (defn- mask->set [mask keys]
- (let [n (-> mask Long/highestOneBit log2 inc)
-       pred #(if (bit-test mask %1) %2 nil)]
-   (->> keys (take n) (keep-indexed pred) (into #{}))))
+  (let [n (bit-shift-right mask (count keys))]
+    (persistent!
+      (loop [acc (transient #{})
+             mask mask
+             keys keys]
+        (if (= mask n)
+          acc
+          (recur
+            (if (odd? mask)
+              (conj! acc (first keys))
+              acc)
+            (bit-shift-right mask 1)
+            (next keys)))))))
 
 (defn- modifiers->set [modifiers]
   (mask->set modifiers [:caps-lock :shift :control :alt :win-logo :linux-meta :linux-super :mac-command :mac-option :mac-fn]))

--- a/test/io/github/humbleui/event_test.clj
+++ b/test/io/github/humbleui/event_test.clj
@@ -1,0 +1,38 @@
+(ns io.github.humbleui.event-test
+  (:require
+    [clojure.test :as test :refer [deftest is are testing]]
+    [io.github.humbleui.event :as event]))
+
+(def ^:private mask->set #'event/mask->set)
+
+(deftest mask->set-test
+  (testing "when mask is zero or empty keys"
+    (are [mask keys res] (= (mask->set mask keys) res)
+      0 [] #{}
+      0 [:a :b :c] #{}
+      42 [] #{}))
+
+  (testing "basic cases"
+    (are [mask keys res] (= (mask->set mask keys) res)
+      1 [:a] #{:a}
+      2 [:a] #{}
+      3 [:a :c] #{:a :c}
+      4 [:a :b :c :d] #{:c}
+      6 [:a :b :c :d] #{:b :c}
+      7 [:a :b :c] #{:a :b :c}
+      16 [:a :b :c :d :t :z] #{:t}
+      32 [:a :b :c :d :t :z] #{:z}
+      255 [:a :b :c :d :t :z] #{:a :b :c :d :t :z}))
+
+  (testing "with very big mask"
+    (are [mask keys res] (= (mask->set mask keys) res)
+      1000007 [:a] #{:a}
+      2000000 [:a] #{}))
+
+  (testing "with very long keys set"
+    (let [million-keys (map #(-> % str keyword) (range 1000000))]
+      (is (= (mask->set 11 million-keys) #{:0 :1 :3})))))
+
+(comment 
+  (test/test-ns *ns*))
+    

--- a/test/io/github/humbleui/event_test.clj
+++ b/test/io/github/humbleui/event_test.clj
@@ -30,8 +30,8 @@
       2000000 [:a] #{}))
 
   (testing "with very long keys set"
-    (let [million-keys (map #(-> % str keyword) (range 1000000))]
-      (is (= (mask->set 11 million-keys) #{:0 :1 :3})))))
+    (let [very-long-keys (mapv #(-> % str keyword) (range 100000))]
+      (is (= (mask->set 11 very-long-keys) #{:0 :1 :3})))))
 
 (comment 
   (test/test-ns *ns*))


### PR DESCRIPTION
Current: 
complexity of the func `event/mask->set` in the worst case is linear to size of the input param `keys`.

Candidate: 
worst case complexity bound by highest bit position in the param `mask`.   