### PR TITLE
Little correction in the padding constructor.

### DIFF
--- a/src/io/github/humbleui/ui/padding.clj
+++ b/src/io/github/humbleui/ui/padding.clj
@@ -31,7 +31,7 @@
 (defn padding
   ([p child]
    (if (map? p)
-     (map->Padding (assoc :child child))
+     (map->Padding (assoc p :child child))
      (map->Padding
        {:left   p
         :top    p


### PR DESCRIPTION
In the case where padding is passed as a map of dimension, the map isn't passed to the assoc function.