### PR TITLE
Add a Nix Flake to solve missing libGL.so for NixOS users

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,58 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1725024810,
+        "narHash": "sha256-ODYRm8zHfLTH3soTFWE452ydPYz2iTvr9T8ftDMUQ3E=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "af510d4a62d071ea13925ce41c95e3dec816c01d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1725032169,
+        "narHash": "sha256-7v5DAwCxA8kuzGD7Wvx4IWWiKeGPoXrSKIcdfsI8FE4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f4e9c7154102a0d48fbf0aaed57ac7a75fc4173c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1722555339,
+        "narHash": "sha256-uFf2QeW7eAHlYXuDktm9c25OxOyCoUOQmh5SZ9amE5Q=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,29 @@
+{
+  description = "HumbleUI - Clojure Desktop UI framework";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/release-24.05";
+  inputs.flake-parts.url = "github:hercules-ci/flake-parts";
+  outputs =
+    inputs:
+    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "aarch64-darwin"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "x86_64-linux"
+      ];
+      perSystem =
+        { pkgs, ... }:
+        {
+          devShells.default = pkgs.mkShell {
+            nativeBuildInputs = with pkgs; [
+              jdk22
+              python3
+            ];
+            LD_LIBRARY_PATH = "${pkgs.libGL}/lib/:$LD_LIBRARY_PATH";
+            shellHook = ''
+              ./script/repl.py
+            '';
+          };
+        };
+    };
+}


### PR DESCRIPTION
NixOS users usually have problems with `libGL.so`, HumbleUI not being immune to this:

```
Execution error (UnsatisfiedLinkError) at jdk.internal.loader.NativeLibraries/load (NativeLibraries.java:-2).
/tmp/skija_0.116.2_x64/libskija.so: libGL.so.1: cannot open shared object file: No such file or directory
```

The way it's solved (until a better solutions shows up, that I'm not aware of right now) is by exporting the correct `LD_LIBRARY_PATH` variable

This is a Nix Flake, to be used by running `nix develop`, it will make `jdk22` and `python3` available only while inside the created shell. It can be improved and more dependencies can be added if more issues arise. The idea is to have all what is needed in one single file that Nix can build automatically, without worrying about versions and other setup.

By the way, I'm fine if this doesn't get merged, at least I want to show that there is a way to run the HumbleUI repl/demo for NixOS users that might be interested.