### PR TITLE
Added CTRL support in textfields on non-MacOS platforms

### DIFF
--- a/src/io/github/humbleui/ui/text_field.clj
+++ b/src/io/github/humbleui/ui/text_field.clj
@@ -869,6 +869,10 @@
                                :z [:redo])
                              
                              (util/when-case (and (not macos?) ctrl?) key
+                               :left [:move-word-left]
+                               :right [:move-word-right]
+                               :backspace [:delete-word-left]
+                               :delete [:delete-word-right]
                                :a [:select-all]
                                :z [:undo]
                                :y [:redo])


### PR DESCRIPTION
Addressing issue #79