### PR TITLE
Text input toggle demo

### DIFF
--- a/dev/examples/text_field.clj
+++ b/dev/examples/text_field.clj
@@ -1,8 +1,9 @@
 (ns examples.text-field
   (:require
-    [io.github.humbleui.util :as util]
-    [io.github.humbleui.signal :as signal]
-    [io.github.humbleui.ui :as ui]))
+   [io.github.humbleui.util :as util]
+   [io.github.humbleui.signal :as signal]
+   [io.github.humbleui.ui :as ui]
+   [io.github.humbleui.window :as window]))
 
 (defn text-field [text & {:keys [from to placeholder cursor-blink-interval cursor-width padding-h padding-v padding-top padding-bottom border-radius]
                           :or {cursor-blink-interval 500, cursor-width 1, padding-h 0, padding-v 3, border-radius 4}
@@ -22,6 +23,8 @@
          :placeholder placeholder
          :from        from
          :to          to}))]])
+
+(def *press-and-hold (ui/signal true))
 
 (defn ui []
   [ui/align {:y :center}
@@ -45,4 +48,11 @@
          [text-field "Align center" :padding-h 5 :padding-v 10]]]
        [ui/size {:width 300}
         [ui/align {:x :right}
-         [text-field "Align right" :padding-h 5 :padding-v 10]]]]]]]])
+         [text-field "Align right" :padding-h 5 :padding-v 10]]]
+       [ui/checkbox {:*value *press-and-hold
+                     :on-change (fn [enabled]
+                                  (window/set-press-and-hold enabled))}
+        [ui/label "Press and hold: " (if @*press-and-hold "ON" "OFF")]]
+       [ui/size {:width 300}
+        [text-field "Press and hold"
+         :from 13 :to 18 :border-radius 0]]]]]]])

--- a/src/io/github/humbleui/window.clj
+++ b/src/io/github/humbleui/window.clj
@@ -7,7 +7,7 @@
     [io.github.humbleui.debug :as debug]
     [io.github.humbleui.event :as event])
   (:import
-    [io.github.humbleui.jwm App MouseCursor Platform TextInputClient Window ZOrder]
+    [io.github.humbleui.jwm App MouseCursor Platform TextInputClient Window WindowMac ZOrder]
     [io.github.humbleui.jwm.skija LayerD3D12Skija LayerGLSkija LayerMetalSkija]
     [io.github.humbleui.skija ColorSpace Surface]
     [io.github.humbleui.types IRect]
@@ -234,3 +234,7 @@
   (let [c (cursors cursor)]
     (assert (some? c) (str "Unknown cursor " cursor))
     (.setMouseCursor window c)))
+
+(defn set-press-and-hold [enabled]
+  (when (= :macos app/platform)
+    (WindowMac/setPressAndHoldEnabled enabled)))


### PR DESCRIPTION
This is a demo that showcases using text input to be toggled between showing the press and hold popup for inserting accent characters and keyrepeat

<img width="734" height="272" alt="image" src="https://github.com/user-attachments/assets/bc859918-3eca-477c-b757-3be83a5d1b33" />

This PR is dependent on #94, it was created separately to allow #94 to be accepted without accepting this one